### PR TITLE
Allow running go from startpos without position

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -23,7 +23,7 @@ int main(int argc, char *argv[]) {
     eg_init();
 
     // Board
-    std::unique_ptr<board_t> board = nullptr;
+    std::unique_ptr<board_t> board = std::make_unique<board_t>("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1");
 
     // Hash
     uint64_t hash_size = 128;


### PR DESCRIPTION
Setting a default board state so we don't need to specify `position startpos` to begin searching.

##chessprogramming sends its regards.